### PR TITLE
Add PR auto-approve option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,40 @@ jobs:
           head: master
 ```
 
+## Auto approve
+
+If you use a workflow which does not allow to merge pull requests without a review 
+("Require pull request reviews before merging" in your [repo settings](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuring-protected-branches))
+you can set `auto_approve` to `true`. In that case you'll have to provide a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
+for a user which is allowed to review the pull requests changes. Make sure the token has at least
+`public_repo` permissions and store the token inside of the [repository secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+
+An example workflow would then look like this:
+
+```yml
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          owner: llvm
+          base: master
+          head: master
+          auto_approve: true
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+```
+
 # Parameters
 
 |  name           |   Optional  |   Default              |   description                                        |
@@ -41,5 +75,9 @@ jobs:
 |   pr_title      | ✅          | Fork Sync              |   Title of the created pull request                  |
 |   pr_message    | ✅          |                        |   Message of the created pull request                |
 |   ignore_fail   | ✅          |                        |   Ignore Exceptions                                  |
+|   auto_approve  | ✅ *        | `false`                |   Automatically approve pull request before merge    |
+|   personal_token| ✅          |                        |   Usertoken for the user to auto approve the pull request   |
 
 ⚠️ $current_repo_owner is your own username!
+
+⚠️ * if `auto_approve` is set to `true` you must provide the `personal_token`! 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,13 @@ inputs:
   ignore_fail:
     description: 'ignore Exceptions'
     required: false
+  auto_approve:
+    description: 'Automatically approve pull request before merge'
+    required: false
+    default: false
+  personal_token:
+    description: 'Usertoken for the user to auto approve the pull request'
+    required: false
 
 runs:
   using: 'node12'

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,16 +51,29 @@ function run() {
         const prTitle = core.getInput('pr_title', { required: false });
         const prMessage = core.getInput('pr_message', { required: false });
         const ignoreFail = core.getInput('ignore_fail', { required: false });
+        const autoApprove = core.getInput('auto_approve', { required: false });
+        const personalToken = core.getInput('personal_token', { required: false });
         try {
             let pr = yield octokit.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, merge_method: mergeMethod, maintainer_can_modify: false });
             yield delay(5);
+            if (autoApprove) {
+                if (!personalToken) {
+                    console.log('Cannot auto-approve, please set "personal_token"-variable');
+                }
+                else {
+                    // Authenticate as current user
+                    const octokitUser = new MyOctokit({ auth: personalToken });
+                    yield octokitUser.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
+                    yield octokitUser.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "APPROVE" });
+                }
+            }
             yield octokit.pulls.merge({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number });
         }
         catch (error) {
             if (error.request.request.retryCount) {
                 console.log(`request failed after ${error.request.request.retryCount} retries with a delay of ${error.request.request.retryAfter}`);
             }
-            if (!!error.errors && error.errors[0].message.startsWith('No commits between')) {
+            if (!!error.errors && !!error.errors[0] && !!error.errors[0].message && error.errors[0].message.startsWith('No commits between')) {
                 console.log('No commits between ' + context.repo.owner + ':' + base + ' and ' + owner + ':' + head);
             }
             else {
@@ -71,7 +84,7 @@ function run() {
         }
     });
 }
-function delay(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms * 1000));
+function delay(s) {
+    return new Promise(resolve => setTimeout(resolve, s * 1000));
 }
 run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,10 +21,23 @@ async function run() {
   const prTitle = core.getInput('pr_title', { required: false });
   const prMessage = core.getInput('pr_message', { required: false });
   const ignoreFail = core.getInput('ignore_fail', { required: false });
+  const autoApprove = core.getInput('auto_approve', { required: false });
+  const personalToken = core.getInput('personal_token', { required: false });
 
   try {
     let pr = await octokit.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, merge_method: mergeMethod, maintainer_can_modify: false });
     await delay(5);
+    if (autoApprove) {
+      if (!personalToken){
+        console.log('Cannot auto-approve, please set "personal_token"-variable');
+      }
+      else {
+        // Authenticate as current user
+        const octokitUser = new MyOctokit({auth: personalToken});
+        await octokitUser.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
+        await octokitUser.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "APPROVE" });
+      }
+    }
     await octokit.pulls.merge({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number });
   } catch (error) {
     if (error.request.request.retryCount) {
@@ -32,7 +45,7 @@ async function run() {
         `request failed after ${error.request.request.retryCount} retries with a delay of ${error.request.request.retryAfter}`
       );
     }
-    if (!!error.errors && error.errors[0].message.startsWith('No commits between')) {
+    if (!!error.errors && !!error.errors[0] && !!error.errors[0].message && error.errors[0].message.startsWith('No commits between')) {
       console.log('No commits between ' + context.repo.owner + ':' + base + ' and ' + owner + ':' + head);
     } else {
       if (!ignoreFail) {
@@ -42,8 +55,8 @@ async function run() {
   }
 }
 
-function delay(ms: number) {
-  return new Promise( resolve => setTimeout(resolve, ms * 1000) );
+function delay(s: number) {
+  return new Promise( resolve => setTimeout(resolve, s * 1000) );
 }
 
 run();


### PR DESCRIPTION
**Problem:**
Personally i use Github branch protection rules to prevent merging into `stable` and `master`-branches without a pull request review. This prevents the `fork-sync` action to automatically merge the changes of the forked repository into my personal fork. Generally speaking i don't want to change the branch-protection-rules because when talking about regular code-changes these make perfectly sense to me.

**What this change implements:**
This PR adds a new feature "auto-approve" which can be activated optionally by setting `auto_approve` and `personal_token` input variables. After the pull request is created by the `fork-sync` action the `auto_approve` variable will be checked. If it's set to `true` the action will approve the changes made by the pull request created before with the user which belongs to the `personal_token`. Also a comment on this review will be generated which makes it clear that this review was automatically generated. Afterwards the `github-actions` bot is able to merge the pull request.

A possible result will look like this:
![image](https://user-images.githubusercontent.com/19730957/95654727-41fef480-0b02-11eb-8711-d13d3fc3e6c7.png)

**This changes solves:**
Branch protection rules regarding the review process can exist next to the `fok-sync` action.

**Also in this PR:**
When testing i noticed that there was a situation where an error occured and `error.errors` was set and contained one element which had no `message` property so i received `Cannot read property 'startsWith' of undefined`.
https://github.com/tgymnich/fork-sync/blob/96717053ce7c6a4680864774d4b43532c0817a7e/src/main.ts#L35
I improved this, too.

Let me know what you think about this

Cheers :-)
