### PR TITLE
Downgrade to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ inputs:
     default: 60
 
 runs:
-  using: 'node18'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
It looks like Node 18 is too new for GitHub hosted runners, and that causes workflow run errors:

![image](https://user-images.githubusercontent.com/7822554/215265235-d5886d4d-0967-48d1-afb8-04c710d5a2df.png)

In fact, [Node 18 is not documented as a supported runtime by GitHub](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing).

To fix this problem, use Node 16 instead, which is explicitly documented as supported by GitHub.