### PR TITLE
Add 'repo' input

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ jobs:
 |  name           |   Optional  |   Default              |   description                                        |
 |---              |---          |---                     |---                                                   |
 |   owner         | ✅          | $current_repo_owner    |   Owner of the forked repository                     |
+|   repo          | ✅          | $current_repo_name     |   Name of the forked repository                      |
 |   token         | ✅          | ${{ github.token }}    |   Token  to access the Github API                    |
 |   head          | ✅          | master                 |   Head branch                                        |
 |   base          | ✅          | master                 |   Base branch                                        |
@@ -74,6 +75,7 @@ jobs:
 |   ignore_fail   | ✅          |                        |   Ignore Exceptions                                  |
 
 ⚠️ $current_repo_owner is your own username!
+⚠️ $current_repo_name is the name of the current repository!
 
 ⚠️ Only provide the branch name for `head` and `base`. `user:branch` will not work! 
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   owner:
     description: 'Owner of the forked repository'
     required: false
+  repo:
+    description: 'Name of the forked repository'
+    required: false
   token:
     description: 'Token for the github API'
     required: false

--- a/lib/main.js
+++ b/lib/main.js
@@ -42,7 +42,7 @@ const MyOctokit = Octokit.plugin(retry);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         let owner = core.getInput('owner', { required: false }) || context.repo.owner;
-        let repo = context.repo.repo;
+        let repo = core.getInput('repo', { required: false }) || context.repo.repo;
         const base = core.getInput('base', { required: false });
         const head = core.getInput('head', { required: false });
         const mergeMethod = core.getInput('merge_method', { required: false });
@@ -69,14 +69,14 @@ function run() {
             repo = r.data.parent.name || repo;
         }
         try {
-            let pr = yield octokit.pulls.create({ owner: context.repo.owner, repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, maintainer_can_modify: false });
+            let pr = yield octokit.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, maintainer_can_modify: false });
             yield delay(20);
             if (autoApprove) {
-                yield octokit.pulls.createReview({ owner: context.repo.owner, repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
-                yield octokit.pulls.createReview({ owner: context.repo.owner, repo, pull_number: pr.data.number, event: "APPROVE" });
+                yield octokit.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
+                yield octokit.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "APPROVE" });
             }
             if (autoMerge) {
-                yield octokit.pulls.merge({ owner: context.repo.owner, repo, pull_number: pr.data.number, merge_method: mergeMethod });
+                yield octokit.pulls.merge({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, merge_method: mergeMethod });
             }
         }
         catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fork-sync",
-  "version": "1.6.3",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fork-sync",
-      "version": "1.6.3",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ const MyOctokit = Octokit.plugin(retry);
 
 async function run() {
   let owner = core.getInput('owner', { required: false }) || context.repo.owner;
-  let repo = context.repo.repo
+  let repo = core.getInput('repo', { required: false}) || context.repo.repo;
   const base = core.getInput('base', { required: false });
   const head = core.getInput('head', { required: false });
   const mergeMethod = core.getInput('merge_method', { required: false });
@@ -39,14 +39,14 @@ async function run() {
   }
 
   try {
-    let pr = await octokit.pulls.create({ owner: context.repo.owner, repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, maintainer_can_modify: false });
+    let pr = await octokit.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, title: prTitle, head: owner + ':' + head, base: base, body: prMessage, maintainer_can_modify: false });
     await delay(20);
     if (autoApprove) {
-        await octokit.pulls.createReview({ owner: context.repo.owner, repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
-        await octokit.pulls.createReview({ owner: context.repo.owner, repo, pull_number: pr.data.number, event: "APPROVE" });
+        await octokit.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "COMMENT", body: "Auto approved" });
+        await octokit.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, event: "APPROVE" });
     }
     if(autoMerge) {
-        await octokit.pulls.merge({ owner: context.repo.owner, repo, pull_number: pr.data.number, merge_method: mergeMethod });
+        await octokit.pulls.merge({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.data.number, merge_method: mergeMethod });
     }
   } catch (error: any) {
     if (error.request.request.retryCount) {


### PR DESCRIPTION
This adds an input `repo` for specifying the upstream repository name, which might be necessary if you forked a repo but renamed it in your user/org.