### PR TITLE
Update action.yml from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ inputs:
     default: 60
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'


### PR DESCRIPTION
Node.js 16 actions are deprecated. This change updates the workflow to use Node.js 20. Reference: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Resolves #168 